### PR TITLE
Disables update on startup if autoupdate is off

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import {
   stopAutoUpdateTimer,
   type ContextProvider,
 } from "./utils/auto-update.js";
-import { hydrateAutoUpdateConfig } from "./utils/settings.js";
+import { hydrateAutoUpdateConfig, getAutoUpdateConfig } from "./utils/settings.js";
 import {
   getExtensionsAutocompleteItems,
   resolveCommand,
@@ -72,8 +72,11 @@ export default function extensionsManager(pi: ExtensionAPI) {
 
     if (!ctx.hasUI) return;
 
-    const getCtx: ContextProvider = () => ctx;
-    startAutoUpdateTimer(pi, getCtx, createAutoUpdateNotificationHandler(ctx));
+    const config = getAutoUpdateConfig(ctx);
+    if (config.enabled && config.intervalMs > 0) {
+      const getCtx: ContextProvider = () => ctx;
+      startAutoUpdateTimer(pi, getCtx, createAutoUpdateNotificationHandler(ctx));
+    }
 
     setImmediate(() => {
       updateStatusBar(ctx).catch((err) => {


### PR DESCRIPTION
Currently, even when auto-update is disabled via `/extensions auto-update never`, the extension still runs package checks when `pi` is opened, greatly increasing loading time.

This happens because `startAutoUpdateTimer()` is called unconditionally during the session bootstrap.

This PR introduces a check against the auto-update config before starting the timer and only starts the timer if auto-update is explicitly enabled and has a valid interval.

P.S. I believe that this is not the best way to do this. Ideally there should be a setting/flag that disables the updates on start-up regardless of the auto-update setting. But my solution works fine for me so I won't pursue this further.