### PR TITLE
chore(deps): update pi packages to 0.74

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,13 +44,13 @@
     "image": "https://i.imgur.com/Ce513Br.png"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*",
-    "@mariozechner/pi-tui": "*"
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.9",
-    "@mariozechner/pi-coding-agent": "^0.70.6",
-    "@mariozechner/pi-tui": "^0.70.6",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
+    "@earendil-works/pi-tui": "^0.74.0",
     "@release-it/conventional-changelog": "^10.0.5",
     "@types/node": "^22.19.10",
     "husky": "^9.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,12 @@ importers:
       '@biomejs/biome':
         specifier: ^2.4.9
         version: 2.4.9
-      '@mariozechner/pi-coding-agent':
-        specifier: ^0.70.6
-        version: 0.70.6(ws@8.20.0)(zod@4.3.6)
-      '@mariozechner/pi-tui':
-        specifier: ^0.70.6
-        version: 0.70.6
+      '@earendil-works/pi-coding-agent':
+        specifier: ^0.74.0
+        version: 0.74.0(ws@8.20.0)(zod@4.3.6)
+      '@earendil-works/pi-tui':
+        specifier: ^0.74.0
+        version: 0.74.0
       '@release-it/conventional-changelog':
         specifier: ^10.0.5
         version: 10.0.6(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(release-it@19.2.4(@types/node@22.19.15))
@@ -38,8 +38,8 @@ importers:
 
 packages:
 
-  '@anthropic-ai/sdk@0.90.0':
-    resolution: {integrity: sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==}
+  '@anthropic-ai/sdk@0.91.1':
+    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -267,6 +267,24 @@ packages:
         optional: true
       conventional-commits-parser:
         optional: true
+
+  '@earendil-works/pi-agent-core@0.74.0':
+    resolution: {integrity: sha512-6GMR7/wwjEJ1EsXLWEz03QOWin4AMrJ/AZoMpgm5DJ6GHsF6q6GOhQbj5Zip4dow3vo/TmBAVqM+vmGfrjGAFQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@earendil-works/pi-ai@0.74.0':
+    resolution: {integrity: sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+
+  '@earendil-works/pi-coding-agent@0.74.0':
+    resolution: {integrity: sha512-Q5GikbB5vRBrsrrf/uvet53rPSQ1sn5I5mO+l7sIobdXYpS04/X2oOc2UHFm90fNdkl3yU+ANTZL0zOtHbnqRw==}
+    engines: {node: '>=20.6.0'}
+    hasBin: true
+
+  '@earendil-works/pi-tui@0.74.0':
+    resolution: {integrity: sha512-1aIfXZp7D/z+1VlZX8BZcs6pgO8rjmil7kwyhctNDsWvce3Yfl8GVgu4eq+I0Mjhr8Cj+ipBiv9CLIzdoyCOIQ==}
+    engines: {node: '>=20.0.0'}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -567,95 +585,73 @@ packages:
       '@types/node':
         optional: true
 
-  '@mariozechner/clipboard-darwin-arm64@0.3.3':
-    resolution: {integrity: sha512-+zhuZGXqVrdkbIRdnwiZNbTJ7V3elq/A+C5d5laJoyhJgWs41eO5NUMkBkj6f23F2L4PRXEhdn5/ktlPx+bG3Q==}
+  '@mariozechner/clipboard-darwin-arm64@0.3.2':
+    resolution: {integrity: sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@mariozechner/clipboard-darwin-universal@0.3.3':
-    resolution: {integrity: sha512-x9aRfTyndVqpEQ44LNNCK/EXZd9y8rWkLQgNhmWpby9PXrjPhNxfjUc2Db4mt4nJjU/4zzO8F5v/XyzlUGSdhQ==}
+  '@mariozechner/clipboard-darwin-universal@0.3.2':
+    resolution: {integrity: sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==}
     engines: {node: '>= 10'}
     os: [darwin]
 
-  '@mariozechner/clipboard-darwin-x64@0.3.3':
-    resolution: {integrity: sha512-6ut/NawB0KiYPCwrirgNp6Br62LntL978q7G6d/Rs2pmPvQb53bP96eUMYl+Y3a7Qk13bGZ4w9rVPFxRE9m9ag==}
+  '@mariozechner/clipboard-darwin-x64@0.3.2':
+    resolution: {integrity: sha512-U1BcVEoidvwIp95+HJswSW+xr28EQiHR7rZjH6pn8Sja5yO4Yoe3yCN0Zm8Lo72BbSOK/fTSq0je7CJpaPCspg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.3':
-    resolution: {integrity: sha512-gf3dH4kBddU1AOyHVB53mjLUFfJAKlTmxTMw51jdeg7eE7IjfEBXVvM4bifMtBxbWkT0eA0FUZ1C0KQ6Z5l6pw==}
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.2':
+    resolution: {integrity: sha512-BsinwG3yWTIjdgNCxsFlip7LkfwPk+ruw/aFCXHUg/fb5XC/Ksp+YMQ7u0LUtiKzIv/7LMXgZInJQH6gxbAaqQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.3':
-    resolution: {integrity: sha512-o1paj2+zmAQ/LaPS85XJCxhNowNQpxYM2cGY6pWvB5Kqmz6hZjl6CzDg5tbf1hZkn/Em6jpOaE2UtMxKdELBDA==}
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.2':
+    resolution: {integrity: sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.3':
-    resolution: {integrity: sha512-dkEhE4ekePJwMbBq9HP1//CFMNmDzA/iV9AXqBfvL5CWmmDIRXqh4A3YZt3tWO/HdMerX+xNCEiR7WiOsIG+UA==}
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.2':
+    resolution: {integrity: sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.3':
-    resolution: {integrity: sha512-lT2yANtTLlEtFBIH3uGoRa/CQas/eBoLNi3qr9axQFoRgF4RGPSJ66yHOSnMECBneTIb1Iqv3UxokTfX27CdoQ==}
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.2':
+    resolution: {integrity: sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@mariozechner/clipboard-linux-x64-musl@0.3.3':
-    resolution: {integrity: sha512-saq/MCB0QHK/7ZZLjAZ0QkbY944dyjOsur8gneGCfMitt+GOiE1CU4OUipHC4b6x8UDY9bRLsR4aBaxu22OFPA==}
+  '@mariozechner/clipboard-linux-x64-musl@0.3.2':
+    resolution: {integrity: sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.3':
-    resolution: {integrity: sha512-cGuvSj0/2X2w983yEcKw+i+r1EBej6ZZIN+fXG3eY2G/HaIQpbXpLvMxKyZ9LKtbZx+Z6q/gELEoSBMLML6BaQ==}
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.2':
+    resolution: {integrity: sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.3':
-    resolution: {integrity: sha512-5hvaEq/bgYovTIGx43O/S7loIHYV3ue90WcV1dz0wdMXroVKZKeU/yfwM0PALQA1OcrEHiGXGySFReXr72lGtA==}
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.2':
+    resolution: {integrity: sha512-tGRuYpZwDOD7HBrCpyRuhGnHHSCknELvqwKKUG4JSfSB7JIU7LKRh6zx6fMUOQd8uISK35TjFg5UcNih+vJhFA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@mariozechner/clipboard@0.3.3':
-    resolution: {integrity: sha512-e7jASirzfm+ROiOGFh843+cFZTy3DfzP+jldCvh8RnEk0C3QihDTn7dd7Yh7KAJydwIJ18FJSZ2swHvCJhk18g==}
+  '@mariozechner/clipboard@0.3.5':
+    resolution: {integrity: sha512-D3F+UrU9CR7roJt0zDLp6Oc+4/KlLDIrN4frH+6V90SJNW2KKUec1oCQIPaaDjCqeOsQyX9dyqYbImIQIM45PA==}
     engines: {node: '>= 10'}
-
-  '@mariozechner/jiti@2.6.5':
-    resolution: {integrity: sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==}
-    hasBin: true
-
-  '@mariozechner/pi-agent-core@0.70.6':
-    resolution: {integrity: sha512-PovJZJqhY4ajgTJRUcLzfWKnlQuJHxHW3T030CafR9LYeLmOHi/HGS8DbCdRgSJNbnoIG+kl67/7++9DKZ2+sg==}
-    engines: {node: '>=20.0.0'}
-
-  '@mariozechner/pi-ai@0.70.6':
-    resolution: {integrity: sha512-LVAadu0Y+hb7Bj7EDiLsx6AuGxHlxDq0euLzyqX698i9qt0BW6a+oQSUIZQz4rJwExF18OvyL7ygJ5781ojrIQ==}
-    engines: {node: '>=20.0.0'}
-    hasBin: true
-
-  '@mariozechner/pi-coding-agent@0.70.6':
-    resolution: {integrity: sha512-S4hUZghBeHPqsL6+DNg/TbGLziSh5+/mEHPVlYq5y6ImirWXhISLdLCnyZUW83OblKWihmG7unhJXiHQTH82mQ==}
-    engines: {node: '>=20.6.0'}
-    hasBin: true
-
-  '@mariozechner/pi-tui@0.70.6':
-    resolution: {integrity: sha512-orBJEwMdpBC38AXfdVBKT5ZvqNTcKg6g3NdoF5a9aNQzDI/dOTu1UNYFYyEOTFRiTxSR1nw8eovbCcaSyekWfw==}
-    engines: {node: '>=20.0.0'}
 
   '@mistralai/mistralai@2.2.1':
     resolution: {integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==}
@@ -940,6 +936,7 @@ packages:
   '@smithy/util-retry@4.3.6':
     resolution: {integrity: sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew==}
     engines: {node: '>=18.0.0'}
+    deprecated: '@smithy/util-retry v4.3.6 contains a bug in Adaptive Retry, see https://github.com/smithy-lang/smithy-typescript/issues/1993. Upgrade to 4.3.7+'
 
   '@smithy/util-stream@4.5.25':
     resolution: {integrity: sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==}
@@ -1486,6 +1483,10 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
@@ -1863,9 +1864,6 @@ packages:
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
-
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
     engines: {node: '>=18'}
@@ -2078,7 +2076,7 @@ packages:
 
 snapshots:
 
-  '@anthropic-ai/sdk@0.90.0(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.91.1(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
@@ -2541,6 +2539,85 @@ snapshots:
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.4.0
 
+  '@earendil-works/pi-agent-core@0.74.0(ws@8.20.0)(zod@4.3.6)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.74.0(ws@8.20.0)(zod@4.3.6)
+      typebox: 1.1.34
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-ai@0.74.0(ws@8.20.0)(zod@4.3.6)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.3.6)
+      '@aws-sdk/client-bedrock-runtime': 3.1039.0
+      '@google/genai': 1.50.1
+      '@mistralai/mistralai': 2.2.1
+      chalk: 5.6.2
+      openai: 6.26.0(ws@8.20.0)(zod@4.3.6)
+      partial-json: 0.1.7
+      proxy-agent: 6.5.0
+      typebox: 1.1.34
+      undici: 7.25.0
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-coding-agent@0.74.0(ws@8.20.0)(zod@4.3.6)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.74.0(ws@8.20.0)(zod@4.3.6)
+      '@earendil-works/pi-ai': 0.74.0(ws@8.20.0)(zod@4.3.6)
+      '@earendil-works/pi-tui': 0.74.0
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cli-highlight: 2.1.11
+      diff: 8.0.4
+      extract-zip: 2.0.1
+      file-type: 21.3.4
+      glob: 13.0.6
+      hosted-git-info: 9.0.2
+      ignore: 7.0.5
+      jiti: 2.7.0
+      marked: 15.0.12
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      strip-ansi: 7.2.0
+      typebox: 1.1.34
+      undici: 7.25.0
+      uuid: 14.0.0
+      yaml: 2.8.3
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.5
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-tui@0.74.0':
+    dependencies:
+      '@types/mime-types': 2.1.4
+      chalk: 5.6.2
+      get-east-asian-width: 1.5.0
+      marked: 15.0.12
+      mime-types: 3.0.2
+    optionalDependencies:
+      koffi: 2.16.1
+
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
 
@@ -2755,133 +2832,49 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.15
 
-  '@mariozechner/clipboard-darwin-arm64@0.3.3':
+  '@mariozechner/clipboard-darwin-arm64@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-darwin-universal@0.3.3':
+  '@mariozechner/clipboard-darwin-universal@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-darwin-x64@0.3.3':
+  '@mariozechner/clipboard-darwin-x64@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.3':
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.3':
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.3':
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.3':
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-linux-x64-musl@0.3.3':
+  '@mariozechner/clipboard-linux-x64-musl@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.3':
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.3':
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard@0.3.3':
+  '@mariozechner/clipboard@0.3.5':
     optionalDependencies:
-      '@mariozechner/clipboard-darwin-arm64': 0.3.3
-      '@mariozechner/clipboard-darwin-universal': 0.3.3
-      '@mariozechner/clipboard-darwin-x64': 0.3.3
-      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.3
-      '@mariozechner/clipboard-linux-arm64-musl': 0.3.3
-      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.3
-      '@mariozechner/clipboard-linux-x64-gnu': 0.3.3
-      '@mariozechner/clipboard-linux-x64-musl': 0.3.3
-      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.3
-      '@mariozechner/clipboard-win32-x64-msvc': 0.3.3
+      '@mariozechner/clipboard-darwin-arm64': 0.3.2
+      '@mariozechner/clipboard-darwin-universal': 0.3.2
+      '@mariozechner/clipboard-darwin-x64': 0.3.2
+      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.2
+      '@mariozechner/clipboard-linux-arm64-musl': 0.3.2
+      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.2
+      '@mariozechner/clipboard-linux-x64-gnu': 0.3.2
+      '@mariozechner/clipboard-linux-x64-musl': 0.3.2
+      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.2
+      '@mariozechner/clipboard-win32-x64-msvc': 0.3.2
     optional: true
-
-  '@mariozechner/jiti@2.6.5':
-    dependencies:
-      std-env: 3.10.0
-      yoctocolors: 2.1.2
-
-  '@mariozechner/pi-agent-core@0.70.6(ws@8.20.0)(zod@4.3.6)':
-    dependencies:
-      '@mariozechner/pi-ai': 0.70.6(ws@8.20.0)(zod@4.3.6)
-      typebox: 1.1.34
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-ai@0.70.6(ws@8.20.0)(zod@4.3.6)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.90.0(zod@4.3.6)
-      '@aws-sdk/client-bedrock-runtime': 3.1039.0
-      '@google/genai': 1.50.1
-      '@mistralai/mistralai': 2.2.1
-      chalk: 5.6.2
-      openai: 6.26.0(ws@8.20.0)(zod@4.3.6)
-      partial-json: 0.1.7
-      proxy-agent: 6.5.0
-      typebox: 1.1.34
-      undici: 7.25.0
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-coding-agent@0.70.6(ws@8.20.0)(zod@4.3.6)':
-    dependencies:
-      '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.70.6(ws@8.20.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.70.6(ws@8.20.0)(zod@4.3.6)
-      '@mariozechner/pi-tui': 0.70.6
-      '@silvia-odwyer/photon-node': 0.3.4
-      chalk: 5.6.2
-      cli-highlight: 2.1.11
-      diff: 8.0.4
-      extract-zip: 2.0.1
-      file-type: 21.3.4
-      glob: 13.0.6
-      hosted-git-info: 9.0.2
-      ignore: 7.0.5
-      marked: 15.0.12
-      minimatch: 10.2.5
-      proper-lockfile: 4.1.2
-      strip-ansi: 7.2.0
-      typebox: 1.1.34
-      undici: 7.25.0
-      uuid: 14.0.0
-      yaml: 2.8.3
-    optionalDependencies:
-      '@mariozechner/clipboard': 0.3.3
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-tui@0.70.6':
-    dependencies:
-      '@types/mime-types': 2.1.4
-      chalk: 5.6.2
-      get-east-asian-width: 1.5.0
-      marked: 15.0.12
-      mime-types: 3.0.2
-    optionalDependencies:
-      koffi: 2.16.1
 
   '@mistralai/mistralai@2.2.1':
     dependencies:
@@ -3862,6 +3855,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jiti@2.7.0: {}
+
   json-bigint@1.0.0:
     dependencies:
       bignumber.js: 9.3.1
@@ -4251,8 +4246,6 @@ snapshots:
       spdx-license-ids: 3.0.23
 
   spdx-license-ids@3.0.23: {}
-
-  std-env@3.10.0: {}
 
   stdin-discarder@0.2.2: {}
 

--- a/src/commands/auto-update.ts
+++ b/src/commands/auto-update.ts
@@ -2,7 +2,7 @@ import {
   type ExtensionAPI,
   type ExtensionCommandContext,
   type ExtensionContext,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import {
   disableAutoUpdate,
   enableAutoUpdate,

--- a/src/commands/cache.ts
+++ b/src/commands/cache.ts
@@ -1,4 +1,4 @@
-import { type ExtensionAPI, type ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { clearSearchCache } from "../packages/discovery.js";
 import { clearRemotePackageInfoCache } from "../ui/remote.js";
 import { clearCache } from "../utils/cache.js";

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -1,4 +1,4 @@
-import { type ExtensionAPI, type ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import {
   type ChangeAction,
   formatChangeEntry,

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,4 +1,4 @@
-import { type ExtensionAPI, type ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { type InstallScope, installPackage } from "../packages/install.js";
 import { notify } from "../utils/notify.js";
 

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -1,5 +1,5 @@
-import { type ExtensionAPI, type ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
-import { type AutocompleteItem } from "@mariozechner/pi-tui";
+import { type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { type AutocompleteItem } from "@earendil-works/pi-tui";
 import {
   promptRemove,
   removePackage,

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -1,4 +1,4 @@
-import { type ExtensionAPI, type ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 
 export type CommandId =
   | "local"

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import {
   type ExtensionAPI,
   type ExtensionCommandContext,
   type ExtensionContext,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import { createAutoUpdateNotificationHandler } from "./commands/auto-update.js";
 import {
   getExtensionsAutocompleteItems,

--- a/src/packages/catalog.ts
+++ b/src/packages/catalog.ts
@@ -4,7 +4,7 @@ import {
   type PackageSource,
   type ProgressEvent,
   SettingsManager,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import { type InstalledPackage, type Scope } from "../types/index.js";
 import { normalizePackageIdentity, parsePackageNameAndVersion } from "../utils/package-source.js";
 

--- a/src/packages/discovery.ts
+++ b/src/packages/discovery.ts
@@ -8,7 +8,7 @@ import {
   type ExtensionCommandContext,
   type ExtensionContext,
   getAgentDir,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import { CACHE_TTL, TIMEOUTS } from "../constants.js";
 import { type InstalledPackage, type NpmPackage, type SearchCache } from "../types/index.js";
 import { parseNpmSource } from "../utils/format.js";

--- a/src/packages/extensions.ts
+++ b/src/packages/extensions.ts
@@ -5,7 +5,7 @@ import { homedir } from "node:os";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
-import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import {
   type InstalledPackage,
   type PackageExtensionEntry,

--- a/src/packages/install.ts
+++ b/src/packages/install.ts
@@ -8,7 +8,7 @@ import {
   type ExtensionAPI,
   type ExtensionCommandContext,
   type ProgressEvent,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import { TIMEOUTS } from "../constants.js";
 import { runTaskWithLoader } from "../ui/async-task.js";
 import { parseChoiceByLabel } from "../utils/command.js";

--- a/src/packages/management.ts
+++ b/src/packages/management.ts
@@ -6,7 +6,7 @@ import {
   type ExtensionCommandContext,
   getAgentDir,
   type ProgressEvent,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import { UI } from "../constants.js";
 import { type InstalledPackage } from "../types/index.js";
 import { runTaskWithLoader } from "../ui/async-task.js";

--- a/src/ui/async-task.ts
+++ b/src/ui/async-task.ts
@@ -3,8 +3,15 @@ import {
   type ExtensionCommandContext,
   type ExtensionContext,
   type Theme,
-} from "@mariozechner/pi-coding-agent";
-import { CancellableLoader, Container, Loader, Spacer, Text, type TUI } from "@mariozechner/pi-tui";
+} from "@earendil-works/pi-coding-agent";
+import {
+  CancellableLoader,
+  Container,
+  Loader,
+  Spacer,
+  Text,
+  type TUI,
+} from "@earendil-works/pi-tui";
 import { hasCustomUI } from "../utils/mode.js";
 
 type AnyContext = ExtensionCommandContext | ExtensionContext;

--- a/src/ui/help.ts
+++ b/src/ui/help.ts
@@ -1,7 +1,7 @@
 /**
  * Help display
  */
-import { type ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { notify } from "../utils/notify.js";
 
 export function showHelp(ctx: ExtensionCommandContext): void {

--- a/src/ui/package-config.ts
+++ b/src/ui/package-config.ts
@@ -7,7 +7,7 @@ import {
   type ExtensionCommandContext,
   getSettingsListTheme,
   type Theme,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import {
   Container,
   Key,
@@ -16,7 +16,7 @@ import {
   SettingsList,
   Spacer,
   Text,
-} from "@mariozechner/pi-tui";
+} from "@earendil-works/pi-tui";
 import { UI } from "../constants.js";
 import {
   applyPackageExtensionStateChanges,

--- a/src/ui/remote.ts
+++ b/src/ui/remote.ts
@@ -5,13 +5,13 @@ import {
   DynamicBorder,
   type ExtensionAPI,
   type ExtensionCommandContext,
+  type KeybindingsManager,
   type Theme,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import {
   Container,
   fuzzyMatch,
   type Focusable,
-  getKeybindings,
   Input,
   Key,
   matchesKey,
@@ -19,7 +19,7 @@ import {
   Text,
   truncateToWidth,
   wrapTextWithAnsi,
-} from "@mariozechner/pi-tui";
+} from "@earendil-works/pi-tui";
 import { CACHE_LIMITS, PAGE_SIZE, TIMEOUTS, UI } from "../constants.js";
 import {
   clearSearchCache,
@@ -552,6 +552,7 @@ class RemotePackageBrowser implements Focusable {
   constructor(
     private readonly packages: NpmPackage[],
     private readonly theme: Theme,
+    private readonly keybindings: KeybindingsManager,
     private readonly browseSource: RemoteBrowseSource,
     private readonly queryLabel: string,
     private readonly totalResults: number,
@@ -578,8 +579,6 @@ class RemotePackageBrowser implements Focusable {
   }
 
   handleBrowseInput(data: string): boolean {
-    const kb = getKeybindings();
-
     if (this.searchActive) {
       if (matchesKey(data, Key.enter)) {
         this.searchActive = false;
@@ -606,22 +605,22 @@ class RemotePackageBrowser implements Focusable {
       return true;
     }
 
-    if (kb.matches(data, "tui.select.up")) {
+    if (this.keybindings.matches(data, "tui.select.up")) {
       this.moveSelection(-1);
       return true;
     }
 
-    if (kb.matches(data, "tui.select.down")) {
+    if (this.keybindings.matches(data, "tui.select.down")) {
       this.moveSelection(1);
       return true;
     }
 
-    if (kb.matches(data, "tui.select.pageUp")) {
+    if (this.keybindings.matches(data, "tui.select.pageUp")) {
       this.moveSelection(-Math.max(1, this.maxVisibleItems - 1));
       return true;
     }
 
-    if (kb.matches(data, "tui.select.pageDown")) {
+    if (this.keybindings.matches(data, "tui.select.pageDown")) {
       this.moveSelection(Math.max(1, this.maxVisibleItems - 1));
       return true;
     }
@@ -811,12 +810,13 @@ async function selectBrowseAction(
   if (!ctx.hasUI) return undefined;
 
   return runCustomUI(ctx, "Remote package browsing", () =>
-    ctx.ui.custom<BrowseAction>((tui, theme, _keybindings, done) => {
+    ctx.ui.custom<BrowseAction>((tui, theme, keybindings, done) => {
       const container = new Container();
       const title = new Text("", 2, 0);
       const browser = new RemotePackageBrowser(
         packages,
         theme,
+        keybindings,
         browseSource,
         plan.displayQuery,
         totalResults,

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -1,7 +1,7 @@
 /**
  * Theme utilities for consistent UI styling across dark/light themes
  */
-import { type Theme } from "@mariozechner/pi-coding-agent";
+import { type Theme } from "@earendil-works/pi-coding-agent";
 
 /**
  * Status icons that work across themes

--- a/src/ui/unified.ts
+++ b/src/ui/unified.ts
@@ -8,13 +8,13 @@ import {
   DynamicBorder,
   type ExtensionAPI,
   type ExtensionCommandContext,
+  type KeybindingsManager,
   type Theme,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import {
   Container,
   type Focusable,
   fuzzyMatch,
-  getKeybindings,
   Input,
   Key,
   matchesKey,
@@ -22,7 +22,7 @@ import {
   Text,
   truncateToWidth,
   wrapTextWithAnsi,
-} from "@mariozechner/pi-tui";
+} from "@earendil-works/pi-tui";
 import { UI } from "../constants.js";
 import {
   discoverExtensions,
@@ -164,7 +164,7 @@ async function showInteractiveOnce(
       ctx,
       "The unified extensions manager",
       () =>
-        ctx.ui.custom<UnifiedAction>((tui, theme, _keybindings, done) => {
+        ctx.ui.custom<UnifiedAction>((tui, theme, keybindings, done) => {
           const container = new Container();
 
           const titleText = new Text("", 2, 0);
@@ -179,6 +179,7 @@ async function showInteractiveOnce(
             items,
             staged,
             theme,
+            keybindings,
             ctx.cwd,
             Math.max(4, Math.min(UI.maxListHeight, tui.terminal.rows - 12)),
             complete,
@@ -637,6 +638,7 @@ class UnifiedManagerBrowser implements Focusable {
     private readonly items: UnifiedItem[],
     private readonly staged: Map<string, State>,
     private readonly theme: Theme,
+    private readonly keybindings: KeybindingsManager,
     private readonly cwd: string,
     private readonly maxVisibleItems: number,
     private readonly onAction: (action: UnifiedAction) => void,
@@ -695,8 +697,6 @@ class UnifiedManagerBrowser implements Focusable {
   }
 
   handleManagerInput(data: string): boolean {
-    const kb = getKeybindings();
-
     if (this.searchActive) {
       if (matchesKey(data, Key.enter)) {
         this.searchActive = false;
@@ -745,22 +745,22 @@ class UnifiedManagerBrowser implements Focusable {
       return true;
     }
 
-    if (kb.matches(data, "tui.select.up")) {
+    if (this.keybindings.matches(data, "tui.select.up")) {
       this.moveSelection(-1);
       return true;
     }
 
-    if (kb.matches(data, "tui.select.down")) {
+    if (this.keybindings.matches(data, "tui.select.down")) {
       this.moveSelection(1);
       return true;
     }
 
-    if (kb.matches(data, "tui.select.pageUp")) {
+    if (this.keybindings.matches(data, "tui.select.pageUp")) {
       this.moveSelection(-Math.max(1, this.maxVisibleItems - 1));
       return true;
     }
 
-    if (kb.matches(data, "tui.select.pageDown")) {
+    if (this.keybindings.matches(data, "tui.select.pageDown")) {
       this.moveSelection(Math.max(1, this.maxVisibleItems - 1));
       return true;
     }

--- a/src/utils/auto-update.ts
+++ b/src/utils/auto-update.ts
@@ -5,7 +5,7 @@ import {
   type ExtensionAPI,
   type ExtensionCommandContext,
   type ExtensionContext,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import { getPackageCatalog } from "../packages/catalog.js";
 import { parseChoiceByLabel } from "./command.js";
 import { logAutoUpdateConfig } from "./history.js";

--- a/src/utils/history.ts
+++ b/src/utils/history.ts
@@ -7,7 +7,7 @@ import { type Dirent } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { type ExtensionAPI, type ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 
 export type ChangeAction =
   | "extension_toggle"

--- a/src/utils/mode.ts
+++ b/src/utils/mode.ts
@@ -1,7 +1,10 @@
 /**
  * UI capability helpers
  */
-import { type ExtensionCommandContext, type ExtensionContext } from "@mariozechner/pi-coding-agent";
+import {
+  type ExtensionCommandContext,
+  type ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
 import { notify } from "./notify.js";
 
 type AnyContext = ExtensionCommandContext | ExtensionContext;

--- a/src/utils/notify.ts
+++ b/src/utils/notify.ts
@@ -1,7 +1,10 @@
 /**
  * Centralized notification handling for UI and non-UI modes
  */
-import { type ExtensionCommandContext, type ExtensionContext } from "@mariozechner/pi-coding-agent";
+import {
+  type ExtensionCommandContext,
+  type ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
 
 export type NotifyLevel = "info" | "warning" | "error";
 

--- a/src/utils/npm-exec.ts
+++ b/src/utils/npm-exec.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import { execPath, platform } from "node:process";
-import { type ExtensionAPI, getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
+import { type ExtensionAPI, getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
 
 interface NpmCommandResolutionOptions {
   platform?: NodeJS.Platform;

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -10,7 +10,7 @@ import {
   type ExtensionAPI,
   type ExtensionCommandContext,
   type ExtensionContext,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import { parseScheduleDuration } from "./duration.js";
 import { fileExists } from "./fs.js";
 import { normalizePackageIdentity } from "./package-source.js";

--- a/src/utils/status.ts
+++ b/src/utils/status.ts
@@ -6,7 +6,7 @@ import {
   type ExtensionCommandContext,
   type ExtensionContext,
   getAgentDir,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import { getPackageCatalog, type PackageCatalog } from "../packages/catalog.js";
 import { getAutoUpdateStatus } from "./auto-update.js";
 import { normalizePackageIdentity } from "./package-source.js";

--- a/src/utils/ui-helpers.ts
+++ b/src/utils/ui-helpers.ts
@@ -1,7 +1,7 @@
 /**
  * Common UI helper patterns
  */
-import { type ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { UI } from "../constants.js";
 import { error as notifyError, notify } from "./notify.js";
 

--- a/test/auto-update.test.ts
+++ b/test/auto-update.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { type ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import extensionsManager from "../src/index.js";
 import { setPackageCatalogFactory } from "../src/packages/catalog.js";
 import {

--- a/test/cache-history.test.ts
+++ b/test/cache-history.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { type ExtensionAPI, type ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { clearMetadataCacheCommand } from "../src/commands/cache.js";
 import { getSearchCache, setSearchCache } from "../src/packages/discovery.js";
 import {

--- a/test/discovery-parser.test.ts
+++ b/test/discovery-parser.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { getInstalledPackages, isSourceInstalled } from "../src/packages/discovery.js";
 import { isPackageSource, normalizePackageSource, parseNpmSource } from "../src/utils/format.js";
 import { getPackageSourceKind, normalizePackageIdentity } from "../src/utils/package-source.js";

--- a/test/helpers/custom-component.ts
+++ b/test/helpers/custom-component.ts
@@ -1,4 +1,33 @@
+import { matchesKey, type KeyId } from "@earendil-works/pi-tui";
+
 const noop = (): undefined => undefined;
+
+const DEFAULT_KEYBINDINGS: Record<string, KeyId | KeyId[]> = {
+  "tui.select.up": "up",
+  "tui.select.down": "down",
+  "tui.select.pageUp": "pageUp",
+  "tui.select.pageDown": "pageDown",
+  "tui.select.confirm": "enter",
+  "tui.select.cancel": ["escape", "ctrl+c"],
+};
+
+const mockKeybindings = {
+  matches(data: string, keybinding: string): boolean {
+    const keys = DEFAULT_KEYBINDINGS[keybinding];
+    if (!keys) return false;
+
+    const keyList = Array.isArray(keys) ? keys : [keys];
+    return keyList.some((key) => matchesKey(data, key));
+  },
+  getKeys(keybinding: string): KeyId[] {
+    const keys = DEFAULT_KEYBINDINGS[keybinding];
+    if (!keys) return [];
+    return Array.isArray(keys) ? [...keys] : [keys];
+  },
+  getEffectiveConfig(): Record<string, KeyId | KeyId[]> {
+    return { ...DEFAULT_KEYBINDINGS };
+  },
+};
 
 export interface TestCustomComponent {
   render(width: number): string[];
@@ -83,7 +112,7 @@ export async function captureCustomComponent<T>(
   )(
     { requestRender: noop, terminal: { rows: height, columns: width } },
     theme,
-    {},
+    mockKeybindings,
     resolveCompletion
   );
 

--- a/test/helpers/mocks.ts
+++ b/test/helpers/mocks.ts
@@ -1,4 +1,4 @@
-import { type ExtensionAPI, type ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 
 export interface ExecResult {
   code: number;

--- a/test/helpers/package-catalog.ts
+++ b/test/helpers/package-catalog.ts
@@ -1,4 +1,4 @@
-import { type ProgressEvent } from "@mariozechner/pi-coding-agent";
+import { type ProgressEvent } from "@earendil-works/pi-coding-agent";
 import {
   type AvailablePackageUpdate,
   type PackageCatalog,

--- a/test/install-remove.test.ts
+++ b/test/install-remove.test.ts
@@ -3,7 +3,7 @@ import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { type ExtensionAPI, type ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import {
   installFromUrl,
   installPackage,

--- a/test/package-config.test.ts
+++ b/test/package-config.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { type ExtensionAPI, initTheme } from "@mariozechner/pi-coding-agent";
+import { type ExtensionAPI, initTheme } from "@earendil-works/pi-coding-agent";
 import { discoverPackageExtensions } from "../src/packages/extensions.js";
 import { type InstalledPackage, type State } from "../src/types/index.js";
 import {

--- a/test/search-regression.test.ts
+++ b/test/search-regression.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { initTheme } from "@mariozechner/pi-coding-agent";
+import { initTheme } from "@earendil-works/pi-coding-agent";
 import { configurePackageExtensions } from "../src/ui/package-config.js";
 import { showInteractive } from "../src/ui/unified.js";
 import { captureCustomComponent } from "./helpers/custom-component.js";

--- a/test/ui-helpers.test.ts
+++ b/test/ui-helpers.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { type ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { confirmReload } from "../src/utils/ui-helpers.js";
 
 void test("confirmReload returns false without reloading when user cancels", async () => {

--- a/test/unified-ui.test.ts
+++ b/test/unified-ui.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { initTheme } from "@mariozechner/pi-coding-agent";
+import { initTheme } from "@earendil-works/pi-coding-agent";
 import { showInteractive } from "../src/ui/unified.js";
 import { captureCustomComponent } from "./helpers/custom-component.js";
 import { createMockHarness } from "./helpers/mocks.js";


### PR DESCRIPTION
## Summary
- update Pi package imports and peer/dev dependencies to the `@earendil-works` 0.74.0 scope
- migrate TypeBox imports from `@sinclair/typebox` to `typebox` 1.x where used
- fix current Pi extension API breakages encountered during the upgrade

## Verification
- `pnpm run check`